### PR TITLE
🐛部屋が二つある状態で部屋番号のリクエストが誤発火するバグを修正

### DIFF
--- a/QuizButton/CreatingRoom/CreatingRoomViewModel.swift
+++ b/QuizButton/CreatingRoom/CreatingRoomViewModel.swift
@@ -147,10 +147,6 @@ extension CreatingRoomViewModel: MultiPeerConnectionDelegate {
                 self.dependency.multiPeerConnectionService.sendData(sessionData, toPeer: [fromPeer])
                 // TODO: 待機中のメンバーに追加
                 self.addStandbyMember(fromPeer)
-            } else {
-                // 部屋番号拒否
-                let sessionData = SessionData(type: SessionType.roomNumberReject, roomNumber: self.UD.roomNumber)
-                self.dependency.multiPeerConnectionService.sendData(sessionData, toPeer: [fromPeer])
             }
         default:
             break

--- a/QuizButton/Entrance/EntranceViewController.swift
+++ b/QuizButton/Entrance/EntranceViewController.swift
@@ -22,9 +22,16 @@ class EntranceViewController: UIViewController {
     private var viewModel: EntranceViewModel!
     
     private let disposeBag = DisposeBag()
+    
+    // インジケーター
+    var indicator = UIActivityIndicatorView()
 
     override func viewDidLoad() {
         super.viewDidLoad()
+        
+        // インジケーターの設定
+        indicator.center = CGPoint(x: self.view.center.x, y: self.view.center.y - 40)
+        self.view.addSubview(indicator)
         
         viewModel = EntranceViewModel(
             dependency: (
@@ -38,6 +45,17 @@ class EntranceViewController: UIViewController {
         roomNumberTextField.rx.text.orEmpty
             .bind(to: viewModel.roomNumberText)
             .disposed(by: disposeBag)
+        
+        viewModel.isInProgress.distinctUntilChanged().drive(onNext: { [weak self] isInProgress in
+            if isInProgress {
+                // インジケーター回転開始
+                self?.indicator.startAnimating()
+                self?.view.endEditing(true)
+            } else {
+                // インジケーター回転終了
+                self?.indicator.stopAnimating()
+            }
+        }).disposed(by: disposeBag)
         
     }
     

--- a/QuizButton/Model/SessionType.swift
+++ b/QuizButton/Model/SessionType.swift
@@ -12,7 +12,6 @@ enum SessionType: String {
     
     case roomNumberRequest // 部屋番号のリクエスト
     case roomNumberApproval // 部屋番号リクエストの承認
-    case roomNumberReject // 部屋番号リクエストの拒否
     
     case kickedFromRoom // 部屋に入った後にホストからキックされた場合
     


### PR DESCRIPTION
・部屋が二つある状態で部屋番号をリクエストすると、部屋番号拒否のアラートが誤って発火するバグを修正